### PR TITLE
修复Android10及以下设备的NoSuchMethodError问题

### DIFF
--- a/app/src/main/java/com/qx/orbit/bili/util/ShizukuUtils.kt
+++ b/app/src/main/java/com/qx/orbit/bili/util/ShizukuUtils.kt
@@ -12,7 +12,11 @@ import android.os.Environment
 
 object ShizukuUtils {
     fun hasManageExternalStoragePermission(): Boolean {
-        return Environment.isExternalStorageManager()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Environment.isExternalStorageManager()
+        } else {
+            false // On older versions, this permission doesn't exist
+        }
     }
     
     fun getShizukuVersionName(context: Context): String? {


### PR DESCRIPTION
代码中调用了 Environment.isExternalStorageManager()，此方法仅存在于 Android 11 (API 30) 及以上系统。在低版本系统上会抛出 NoSuchMethodError。通过加入Android 版本兼容性检查，确保应用在不同 Android 版本上都能正常运行。