### PR TITLE
Optimize player and Wear scrolling; add watch controls

### DIFF
--- a/app/src/main/baseline-prof.txt
+++ b/app/src/main/baseline-prof.txt
@@ -1,0 +1,16 @@
+# Keep Orbit's native Wear Compose screens and list item render paths compiled
+# ahead of time. Wear Compose 1.6.2 marks its transforming-list implementation
+# as post-startup only, so explicitly mark the native scroll/transform paths hot
+# as well as the app-side composables and state reads invoked around them.
+HPLandroidx/wear/compose/foundation/lazy/**->**(**)**
+HPLandroidx/wear/compose/material3/lazy/**->**(**)**
+HPLandroidx/wear/compose/material3/SurfaceTransformation**->**(**)**
+HPLandroidx/wear/compose/material3/SwipeToReveal**->**(**)**
+HPLandroidx/wear/compose/material3/TransformingLazyColumnStateAdapter;->**(**)**
+HSPLcom/qx/orbit/bili/OrbitApp;->**(**)**
+HSPLcom/qx/orbit/bili/presentation/MainActivity;->**(**)**
+HSPLcom/qx/orbit/bili/presentation/MainActivityKt**->**(**)**
+HPLcom/qx/orbit/bili/presentation/**->**(**)**
+HPLcom/qx/orbit/bili/data/model/**->**(**)**
+HPLcom/qx/orbit/bili/util/FormatUtil**->**(**)**
+HPLcom/qx/orbit/bili/util/TimeUtil**->**(**)**

--- a/app/src/main/java/com/qx/orbit/bili/data/api/PlayerApi.kt
+++ b/app/src/main/java/com/qx/orbit/bili/data/api/PlayerApi.kt
@@ -223,7 +223,6 @@ object PlayerApi {
                 dashData = dashData,
                 videoUrl = selectedVideo?.baseUrl ?: (videoStreams.firstOrNull { it.codecid == 7 } ?: videoStreams.firstOrNull())?.baseUrl ?: "",
                 audioUrl = selectedAudio?.baseUrl ?: audioStreams.firstOrNull()?.baseUrl ?: "",
-                progress = data.quality,
                 qnStrList = data.accept_description?.toTypedArray(),
                 qnValueList = data.accept_quality?.toIntArray()
             )

--- a/app/src/main/java/com/qx/orbit/bili/presentation/MainActivity.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/MainActivity.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import android.os.Build
+import android.view.InputDevice
+import android.view.MotionEvent
 import androidx.core.content.ContextCompat
 import android.content.pm.PackageManager
 import androidx.activity.ComponentActivity
@@ -159,6 +161,9 @@ import com.qx.orbit.bili.presentation.viewmodel.HistoryViewModel
 import com.qx.orbit.bili.presentation.viewmodel.WatchLaterViewModel
 
 class MainActivity : ComponentActivity() {
+    private val simulatedRotaryHandlers = linkedMapOf<Int, (Float) -> Boolean>()
+    private var nextSimulatedRotaryHandlerId = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         actionBar?.hide()
@@ -172,6 +177,34 @@ class MainActivity : ComponentActivity() {
         VideoDownloadManager.init(this)
         setContent {
             WearApp()
+        }
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_SCROLL &&
+            event.isFromSource(InputDevice.SOURCE_CLASS_POINTER)
+        ) {
+            val delta = event.getAxisValue(MotionEvent.AXIS_VSCROLL)
+            if (delta != 0f && dispatchSimulatedRotaryInput(delta)) {
+                return true
+            }
+        }
+        return super.dispatchGenericMotionEvent(event)
+    }
+
+    fun registerSimulatedRotaryHandler(handler: (Float) -> Boolean): Int {
+        val id = ++nextSimulatedRotaryHandlerId
+        simulatedRotaryHandlers[id] = handler
+        return id
+    }
+
+    fun unregisterSimulatedRotaryHandler(id: Int) {
+        simulatedRotaryHandlers.remove(id)
+    }
+
+    private fun dispatchSimulatedRotaryInput(delta: Float): Boolean {
+        return simulatedRotaryHandlers.values.toList().asReversed().any { handler ->
+            handler(delta)
         }
     }
 }

--- a/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerControlLayout.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerControlLayout.kt
@@ -1,0 +1,32 @@
+package com.qx.orbit.bili.presentation.player
+
+import com.qx.orbit.bili.util.SharedPreferencesUtil
+
+internal const val PLAYER_ACTION_NONE = 0
+internal const val PLAYER_ACTION_DANMAKU = 1
+internal const val PLAYER_ACTION_SPEED = 2
+internal const val PLAYER_ACTION_VOLUME = 3
+internal const val PLAYER_ACTION_SUBTITLE = 4
+internal const val PLAYER_ACTION_ROTATE = 5
+internal const val PLAYER_ACTION_SCALE = 6
+
+internal data class PlayerControlLayout(
+    val leftTop: Int,
+    val leftBottom: Int,
+    val rightTop: Int,
+    val rightBottom: Int
+)
+
+internal fun loadPlayerControlLayout(): PlayerControlLayout {
+    return PlayerControlLayout(
+        leftTop = SharedPreferencesUtil.getInt(PLAYER_LEFT_TOP_KEY, PLAYER_ACTION_SCALE),
+        leftBottom = SharedPreferencesUtil.getInt(PLAYER_LEFT_BOTTOM_KEY, PLAYER_ACTION_ROTATE),
+        rightTop = SharedPreferencesUtil.getInt(PLAYER_RIGHT_TOP_KEY, PLAYER_ACTION_SPEED),
+        rightBottom = SharedPreferencesUtil.getInt(PLAYER_RIGHT_BOTTOM_KEY, PLAYER_ACTION_DANMAKU)
+    )
+}
+
+internal const val PLAYER_LEFT_TOP_KEY = "player_custom_btn_left"
+internal const val PLAYER_LEFT_BOTTOM_KEY = "player_custom_btn_left_bottom"
+internal const val PLAYER_RIGHT_TOP_KEY = "player_custom_btn_right"
+internal const val PLAYER_RIGHT_BOTTOM_KEY = "player_custom_btn_right_bottom"

--- a/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerScreen.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -61,7 +60,6 @@ import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.material.icons.filled.ScreenRotationAlt
 import androidx.compose.material.icons.rounded.ScreenRotation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -75,13 +73,13 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
@@ -132,16 +130,15 @@ import coil.request.ImageRequest
 import coil.request.SuccessResult
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.material3.VolumeScreen
-import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import com.qx.orbit.bili.BuildConfig
 import com.qx.orbit.bili.R
 import com.qx.orbit.bili.data.api.CookiesApi
 import com.qx.orbit.bili.data.api.DanmakuApi
-import com.qx.orbit.bili.data.api.HeartbeatApi
-import com.qx.orbit.bili.data.api.HistoryApi
 import com.qx.orbit.bili.data.api.LiveApi
 import com.qx.orbit.bili.data.api.PlayerApi
 import com.qx.orbit.bili.data.model.PlayerData
 import com.qx.orbit.bili.data.remote.CookieManager
+import com.qx.orbit.bili.data.remote.HttpClient
 import com.qx.orbit.bili.presentation.theme.LocalScreenRound
 import com.qx.orbit.bili.presentation.theme.extractSeedColorFromBitmap
 import com.qx.orbit.bili.presentation.theme.generateWearColorSchemeFromSeed
@@ -163,12 +160,10 @@ import com.qx.orbit.bili.util.danmaku.base.createEmptyParser
 import com.qx.orbit.bili.util.danmaku.base.createProtobufParser
 import com.qx.orbit.bili.util.danmaku.base.createXmlParser
 import com.qx.orbit.bili.util.player.OrbitPlayer
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.isActive
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket
 import java.io.File
@@ -176,7 +171,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("unused")
-@OptIn(ExperimentalHorologistApi::class, DelicateCoroutinesApi::class)
+@OptIn(ExperimentalHorologistApi::class)
 @SuppressLint("DefaultLocale")
 @Composable
 fun PlayerScreen(
@@ -187,7 +182,9 @@ fun PlayerScreen(
 ) {
     val context = LocalContext.current
     viewModel.initPlayer(context)
-    viewModel.setData(initialData)
+    LaunchedEffect(initialData) {
+        viewModel.setData(initialData)
+    }
     var backPressedTime by remember { mutableLongStateOf(0L) }
     var isExiting by remember { mutableStateOf(false) }
     var isAudioOnlyMode by remember { mutableStateOf(false) }
@@ -228,8 +225,6 @@ fun PlayerScreen(
     
     var showVolumeScreen by remember { mutableStateOf(false) }
     var showMoreDialog by remember { mutableStateOf(false) }
-    val volumeFocusRequester = remember { FocusRequester() }
-
     val audioManager = remember { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
     
     val isAutoLandscape = remember { SharedPreferencesUtil.getBoolean("player_autolandscape", false) }
@@ -294,6 +289,7 @@ fun PlayerScreen(
             isActive = true
         }
     }
+    val latestPlayerData by rememberUpdatedState(playerData)
 
     val audioFocusListener = remember { AudioManager.OnAudioFocusChangeListener { } }
     LaunchedEffect(isPlaying) {
@@ -324,13 +320,14 @@ fun PlayerScreen(
             }
             
             override fun onSkipToNext() {
-                if (playerData.currentPageIndex + 1 < playerData.cids.size) {
-                    val nextIndex = playerData.currentPageIndex + 1
-                    val nextAid = if (playerData.aids.size > nextIndex) playerData.aids[nextIndex] else playerData.aid
-                    val nextCid = playerData.cids[nextIndex]
-                    val nextEpid = if (playerData.epids.size > nextIndex) playerData.epids[nextIndex] else playerData.epid
-                    val nextTitle = if (playerData.pagenames.size > nextIndex) playerData.pagenames[nextIndex] else playerData.title
-                    playerData = playerData.copy(
+                val data = latestPlayerData
+                if (data.currentPageIndex + 1 < data.cids.size) {
+                    val nextIndex = data.currentPageIndex + 1
+                    val nextAid = if (data.aids.size > nextIndex) data.aids[nextIndex] else data.aid
+                    val nextCid = data.cids[nextIndex]
+                    val nextEpid = if (data.epids.size > nextIndex) data.epids[nextIndex] else data.epid
+                    val nextTitle = if (data.pagenames.size > nextIndex) data.pagenames[nextIndex] else data.title
+                    playerData = data.copy(
                         currentPageIndex = nextIndex,
                         aid = nextAid,
                         cid = nextCid,
@@ -343,13 +340,14 @@ fun PlayerScreen(
             }
             
             override fun onSkipToPrevious() {
-                if (playerData.currentPageIndex - 1 >= 0) {
-                    val prevIndex = playerData.currentPageIndex - 1
-                    val prevAid = if (playerData.aids.size > prevIndex) playerData.aids[prevIndex] else playerData.aid
-                    val prevCid = playerData.cids[prevIndex]
-                    val prevEpid = if (playerData.epids.size > prevIndex) playerData.epids[prevIndex] else playerData.epid
-                    val prevTitle = if (playerData.pagenames.size > prevIndex) playerData.pagenames[prevIndex] else playerData.title
-                    playerData = playerData.copy(
+                val data = latestPlayerData
+                if (data.currentPageIndex - 1 >= 0) {
+                    val prevIndex = data.currentPageIndex - 1
+                    val prevAid = if (data.aids.size > prevIndex) data.aids[prevIndex] else data.aid
+                    val prevCid = data.cids[prevIndex]
+                    val prevEpid = if (data.epids.size > prevIndex) data.epids[prevIndex] else data.epid
+                    val prevTitle = if (data.pagenames.size > prevIndex) data.pagenames[prevIndex] else data.title
+                    playerData = data.copy(
                         currentPageIndex = prevIndex,
                         aid = prevAid,
                         cid = prevCid,
@@ -379,7 +377,24 @@ fun PlayerScreen(
         }
     }
 
-    LaunchedEffect(isPlaying, isPrepared, playbackSpeed, playerData.title, totalDuration) {
+    var mediaArt by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    LaunchedEffect(playerData.cover) {
+        mediaArt = null
+        if (playerData.cover.isNotEmpty()) {
+            try {
+                val request = ImageRequest.Builder(context)
+                    .data(playerData.cover.replace("http://", "https://"))
+                    .size(512)
+                    .build()
+                val result = context.imageLoader.execute(request)
+                if (result is SuccessResult) {
+                    mediaArt = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    LaunchedEffect(isPlaying, isPrepared, playerData.title, totalDuration, mediaArt) {
         if (isPrepared) {
             val metadataBuilder = MediaMetadata.Builder()
                 .putString(MediaMetadata.METADATA_KEY_TITLE, playerData.title)
@@ -389,33 +404,11 @@ fun PlayerScreen(
                 .putString(MediaMetadata.METADATA_KEY_ALBUM, "Orbit")
                 .putLong(MediaMetadata.METADATA_KEY_DURATION, totalDuration)
                 
-            if (playerData.cover.isNotEmpty()) {
-                try {
-                    val request = ImageRequest.Builder(context)
-                        .data(playerData.cover.replace("http://", "https://"))
-                        .size(512)
-                        .build()
-                    val result = context.imageLoader.execute(request)
-                    if (result is SuccessResult) {
-                        val drawable = result.drawable
-                        val bitmap = if (drawable is android.graphics.drawable.BitmapDrawable) {
-                            drawable.bitmap
-                        } else null
-                        if (bitmap != null) {
-                            metadataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ART, bitmap)
-                            metadataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, bitmap)
-                        }
-                    }
-                } catch (e: Exception) {}
+            mediaArt?.let { bitmap ->
+                metadataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ART, bitmap)
+                metadataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, bitmap)
             }
             mediaSession.setMetadata(metadataBuilder.build())
-
-            val state = if (isPlaying) PlaybackState.STATE_PLAYING else PlaybackState.STATE_PAUSED
-            val playbackState = PlaybackState.Builder()
-                .setActions(PlaybackState.ACTION_PLAY or PlaybackState.ACTION_PAUSE or PlaybackState.ACTION_PLAY_PAUSE or PlaybackState.ACTION_SKIP_TO_NEXT or PlaybackState.ACTION_SKIP_TO_PREVIOUS or PlaybackState.ACTION_SEEK_TO)
-                .setState(state, currentProgress, playbackSpeed)
-                .build()
-            mediaSession.setPlaybackState(playbackState)
             
             val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
@@ -466,12 +459,13 @@ fun PlayerScreen(
         }
     }
 
-    LaunchedEffect(currentProgress) {
+    LaunchedEffect(vmCurrentProgress, isPrepared, isPlaying, playbackSpeed) {
         if (isPrepared) {
             val state = if (isPlaying) PlaybackState.STATE_PLAYING else PlaybackState.STATE_PAUSED
+            val sessionPosition = try { viewModel.player.currentPosition } catch (_: Exception) { vmCurrentProgress }
             val playbackState = PlaybackState.Builder()
                 .setActions(PlaybackState.ACTION_PLAY or PlaybackState.ACTION_PAUSE or PlaybackState.ACTION_PLAY_PAUSE or PlaybackState.ACTION_SKIP_TO_NEXT or PlaybackState.ACTION_SKIP_TO_PREVIOUS or PlaybackState.ACTION_SEEK_TO)
-                .setState(state, currentProgress, playbackSpeed)
+                .setState(state, sessionPosition, playbackSpeed)
                 .build()
             mediaSession.setPlaybackState(playbackState)
         }
@@ -479,7 +473,6 @@ fun PlayerScreen(
 
     var liveWebSocket by remember { mutableStateOf<WebSocket?>(null) }
     var surfaceHolder by remember { mutableStateOf<SurfaceHolder?>(null) }
-    var surfaceReady by remember { mutableStateOf(false) }
     var textureSurface by remember { mutableStateOf<Surface?>(null) }
     val isTextureViewOk = remember { mutableIntStateOf(SharedPreferencesUtil.getInt("isTextureViewOk", 0)) }
     val showTextureDialog = remember { mutableStateOf(false) }
@@ -514,13 +507,16 @@ fun PlayerScreen(
             if (isPlaying) {
                 danmakuPlayer.resume()
                 while (isActive) {
-                    androidx.compose.runtime.withFrameMillis { }
                     currentProgress = viewModel.player.currentPosition
                     viewModel.updateCurrentSubtitle(currentProgress)
+                    // Player chrome and subtitles do not need display-refresh-rate updates.
+                    // Keeping this at 4 Hz avoids recomposing the full player on every frame.
+                    delay(250.milliseconds)
                 }
             } else {
                 danmakuPlayer.pause()
                 currentProgress = viewModel.player.currentPosition
+                viewModel.updateCurrentSubtitle(currentProgress)
             }
         }
     }
@@ -528,6 +524,7 @@ fun PlayerScreen(
     LaunchedEffect(vmCurrentProgress) {
         if (isPrepared && !isPlaying) {
             currentProgress = vmCurrentProgress
+            viewModel.updateCurrentSubtitle(currentProgress)
         }
     }
 
@@ -553,13 +550,33 @@ fun PlayerScreen(
             viewModel.setLoading(false)
             return@LaunchedEffect
         }
-        viewModel.setLoading(true)
+        viewModel.beginPlaybackPreparation()
         lastLoadId = loadId
         try {
             danmakuPlayer.removeAllDanmakus(true)
             
             if (!isLocal && !CookieManager.getCookie().contains("buvid3")) {
                 CookiesApi.checkCookies()
+            }
+
+            // Fetch the playback URL while the danmaku engine is being prepared.
+            // Both are required before playback starts, but neither depends on the other.
+            val playbackData = async {
+                if (isLive || isLocal) {
+                    playerData
+                } else {
+                    val media3Selected = !BuildConfig.HAS_IJK ||
+                        SharedPreferencesUtil.getString("player_engine", "ijk") == "media3"
+                    val requestDash = SharedPreferencesUtil.getBoolean("player_request_dash", false)
+                    val shouldUseDash = isAudioOnlyMode || (media3Selected && requestDash)
+                    if (playerData.type == PlayerData.TYPE_BANGUMI) {
+                        PlayerApi.getBangumi(playerData, forceMp4 = !shouldUseDash)
+                    } else if (shouldUseDash) {
+                        PlayerApi.getVideoDash(playerData)
+                    } else {
+                        PlayerApi.getVideo(playerData)
+                    }
+                }
             }
 
             val danmakuTextScale = SharedPreferencesUtil.getFloat("player_danmaku_textsize", 1.0f) * 0.8f
@@ -670,16 +687,18 @@ fun PlayerScreen(
                 }
             }
 
-            val result = if (isLive || isLocal) playerData 
-                         else if (playerData.type == PlayerData.TYPE_BANGUMI) {
-                             PlayerApi.getBangumi(playerData)
-                         } else {
-                             if (isAudioOnlyMode) PlayerApi.getVideoDash(playerData) else PlayerApi.getVideo(playerData)
-                         }
+            val result = playbackData.await()
             if (!isLive && !isLocal) playerData = result
             if (result.videoUrl.isNotEmpty() || result.audioUrl.isNotEmpty()) {
                 mediaPlayer.reset()
-                mediaPlayer.setDashData(result.dashData, result.videoUrl, result.audioUrl)
+                val useAudioOnlySource = !isLocal && isAudioOnlyMode && result.audioUrl.isNotEmpty()
+                if (useAudioOnlySource) {
+                    // Media3 would otherwise merge the DASH video track back in, defeating
+                    // background audio-only mode and continuing video decode off-screen.
+                    mediaPlayer.setDashData(null, result.audioUrl, "")
+                } else {
+                    mediaPlayer.setDashData(result.dashData, result.videoUrl, result.audioUrl)
+                }
                 mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "enable-accurate-seek", 1)
                 mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_FORMAT, "allowed_extensions", "ALL")
                 mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_FORMAT, "protocol_whitelist", "file,http,https,tcp,tls,crypto")
@@ -697,6 +716,13 @@ fun PlayerScreen(
                     mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "packet-buffering", 0)
                     mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "infbuf", 1)
                 }
+                if (BuildConfig.HAS_IJK) {
+                    mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "vn", if (useAudioOnlySource) 1 else 0)
+                }
+                if (useAudioOnlySource) {
+                    mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "max-buffer-size", 1024 * 1024)
+                    mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "enable-accurate-seek", 0)
+                }
                 val playUrl = if (!isLocal && isAudioOnlyMode && result.audioUrl.isNotEmpty()) result.audioUrl else result.videoUrl
                 mediaPlayer.dataSource = playUrl
                 if (effectiveUseTexture) {
@@ -711,7 +737,6 @@ fun PlayerScreen(
                 if (SharedPreferencesUtil.getBoolean("player_loop", false)) {
                     mediaPlayer.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "loop", 1)
                 }
-                mediaPlayer.prepareAsync()
                 var hasPrepared = false
                 mediaPlayer.setOnPreparedListener {
                     if (hasPrepared) return@setOnPreparedListener
@@ -758,6 +783,8 @@ fun PlayerScreen(
                     }
                     true
                 }
+                // Install callbacks before preparing; local sources can become ready quickly.
+                mediaPlayer.prepareAsync()
             } else {
                 viewModel.setError("无法获取视频地址")
                 viewModel.setLoading(false)
@@ -780,6 +807,8 @@ fun PlayerScreen(
                     val buvid = CookieManager.getCookie().split("; ")
                         .find { it.startsWith("buvid3=") }?.substringAfter("=") ?: ""
                     val mid = CookieManager.getMid()
+                    val showDanmakuSender = SharedPreferencesUtil.getBoolean("player_danmaku_showsender", true)
+                    val liveDanmakuDensityScale = context.resources.displayMetrics.density - 0.6f
 
                     val callback = object : PlayerCallback {
                         @SuppressLint("LocalContextResourcesRead")
@@ -787,15 +816,14 @@ fun PlayerScreen(
                             try {
                                 val config = danmakuConfig ?: return
                                 val item = createDanmaku(config, type) ?: return
-                                val showSender = SharedPreferencesUtil.getBoolean("player_danmaku_showsender", true)
-                                val displayText = if (!showSender && senderName.isNotEmpty()) {
+                                val displayText = if (!showDanmakuSender && senderName.isNotEmpty()) {
                                     text.removePrefix("$senderName：")
                                 } else text
                                 item.text = displayText
                                 item.padding = 5
                                 item.priority = 1
                                 item.textColor = color
-                                item.textSize = textSize * (context.resources.displayMetrics.density - 0.6f)
+                                item.textSize = textSize * liveDanmakuDensityScale
                                 item.time = danmakuPlayer.getCurrentTime() + 100
                                 
                                 if (borderColor != 0) {
@@ -825,14 +853,14 @@ fun PlayerScreen(
                         callback = callback
                     )
 
-                    val client = OkHttpClient()
                     val request = Request.Builder()
                         .url(url)
                         .header("Cookie", CookieManager.getCookie())
                         .header("Origin", "https://live.bilibili.com")
                         .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.95 Safari/537.36")
                         .build()
-                    liveWebSocket = client.newWebSocket(request, listener)
+                    liveWebSocket?.close(1000, "reconnect")
+                    liveWebSocket = HttpClient.client.newWebSocket(request, listener)
                     Log.d("BiliApi", "PlayerScreen danmaku WS connecting to $url, uid=$mid, roomid=${playerData.aid}")
                 }
             } catch (_: Exception) {}
@@ -891,35 +919,12 @@ fun PlayerScreen(
     
     DisposableEffect(Unit) {
         view.keepScreenOn = true
-        val startTs = System.currentTimeMillis() / 1000
         onDispose {
             view.keepScreenOn = false
 
             if (!isLive && playerData.type != PlayerData.TYPE_LOCAL) {
-                val currentPosSeconds = currentProgress / 1000
-                
+                val currentPosSeconds = viewModel.savePosition() / 1000
                 onDisposeAction(playerData.epid, currentPosSeconds)
-
-                GlobalScope.launch {
-                    try {
-                        val isBangumi = playerData.type == PlayerData.TYPE_BANGUMI && playerData.epid > 0
-                        if (!isBangumi) {
-                            HistoryApi.reportHistory(playerData.aid, playerData.cid, currentPosSeconds)
-                        }
-                        HeartbeatApi.reportHeartbeat(
-                            aid = playerData.aid,
-                            bvid = playerData.bvid,
-                            cid = playerData.cid,
-                            playedTime = currentPosSeconds,
-                            startTs = startTs,
-                            type = if (isBangumi) "4" else "3",
-                            subType = if (isBangumi) "1" else null,
-                            epid = if (isBangumi) playerData.epid else null,
-                            sid = if (isBangumi) playerData.sid else null,
-                            videoDuration = (totalDuration / 1000).coerceAtLeast(0)
-                        )
-                    } catch (e: Exception) {}
-                }
             }
 
             liveWebSocket?.close(1000, "bye")
@@ -1155,7 +1160,7 @@ fun PlayerScreen(
                                 }
                                 surfaceTextureListener = object : TextureView.SurfaceTextureListener {
                                     override fun onSurfaceTextureAvailable(surface: SurfaceTexture, width: Int, height: Int) {
-                                        surfaceReady = true
+                                        textureSurface?.release()
                                         val s = Surface(surface)
                                         textureSurface = s
                                         mediaPlayer.setSurface(s)
@@ -1163,9 +1168,9 @@ fun PlayerScreen(
 
                                     override fun onSurfaceTextureSizeChanged(surface: SurfaceTexture, width: Int, height: Int) {}
                                     override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
-                                        surfaceReady = false
-                                        textureSurface = null
                                         mediaPlayer.setSurface(null)
+                                        textureSurface?.release()
+                                        textureSurface = null
                                         return true
                                     }
 
@@ -1183,13 +1188,11 @@ fun PlayerScreen(
                                 holder.addCallback(object : SurfaceHolder.Callback {
                                     override fun surfaceCreated(h: SurfaceHolder) {
                                         surfaceHolder = h
-                                        surfaceReady = true
                                         mediaPlayer.setDisplay(h)
                                     }
                                     override fun surfaceChanged(h: SurfaceHolder, f: Int, w: Int, height: Int) {}
                                     override fun surfaceDestroyed(h: SurfaceHolder) {
                                         surfaceHolder = null
-                                        surfaceReady = false
                                         mediaPlayer.setDisplay(null)
                                     }
                                 })

--- a/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerScreen.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerScreen.kt
@@ -53,7 +53,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.PanoramaFishEye
 import androidx.compose.material.icons.filled.ScreenRotation
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.rounded.Pause
@@ -92,7 +95,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalViewConfiguration
@@ -140,6 +145,7 @@ import com.qx.orbit.bili.data.model.PlayerData
 import com.qx.orbit.bili.data.remote.CookieManager
 import com.qx.orbit.bili.data.remote.HttpClient
 import com.qx.orbit.bili.presentation.theme.LocalScreenRound
+import com.qx.orbit.bili.presentation.MainActivity
 import com.qx.orbit.bili.presentation.theme.extractSeedColorFromBitmap
 import com.qx.orbit.bili.presentation.theme.generateWearColorSchemeFromSeed
 import com.qx.orbit.bili.presentation.ui.components.RoundToast
@@ -167,6 +173,9 @@ import kotlinx.coroutines.isActive
 import okhttp3.Request
 import okhttp3.WebSocket
 import java.io.File
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -215,10 +224,11 @@ fun PlayerScreen(
     var showDanmaku by remember { mutableStateOf(SharedPreferencesUtil.getBoolean("player_danmaku_default_show", true)) }
     val isPlaying by viewModel.isPlaying.collectAsState()
     
-    val leftTopBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_left", 2)) }
-    val leftBottomBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_left_bottom", 0)) }
-    val rightTopBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_right", 1)) }
-    val rightBottomBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_right_bottom", 0)) }
+    val controlLayout = remember { loadPlayerControlLayout() }
+    val leftTopBtnAction = controlLayout.leftTop
+    val leftBottomBtnAction = controlLayout.leftBottom
+    val rightTopBtnAction = controlLayout.rightTop
+    val rightBottomBtnAction = controlLayout.rightBottom
     
     val subtitleLinks by viewModel.subtitleLinks.collectAsState()
     var showSubtitleDialog by remember { mutableStateOf(false) }
@@ -226,6 +236,11 @@ fun PlayerScreen(
     var showVolumeScreen by remember { mutableStateOf(false) }
     var showMoreDialog by remember { mutableStateOf(false) }
     val audioManager = remember { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
+    val volumeState = rememberPlayerVolumeState(
+        guardEnabled = true,
+        playbackStartVolumeLimitPercent = 10
+    )
+    val simulatedRotaryHost = remember(context) { context.findActivity() as? MainActivity }
     
     val isAutoLandscape = remember { SharedPreferencesUtil.getBoolean("player_autolandscape", false) }
     val isSoftRotate = remember { SharedPreferencesUtil.getBoolean("player_softrotate", false) }
@@ -283,6 +298,24 @@ fun PlayerScreen(
     val mediaPlayer = viewModel.player
     val danmakuPlayer = remember { createDanmakuPlayer(context) }
     var danmakuConfig by remember { mutableStateOf<DanmakuConfig?>(null) }
+
+    DisposableEffect(simulatedRotaryHost, volumeState) {
+        val handlerId = simulatedRotaryHost?.registerSimulatedRotaryHandler { rawDelta ->
+            val delta = -rawDelta * ROTARY_VOLUME_INPUT_SCALE
+            if (delta == 0f) {
+                false
+            } else {
+                volumeState.adjustByDelta(delta)
+                interactionCounter++
+                true
+            }
+        }
+        onDispose {
+            if (handlerId != null) {
+                simulatedRotaryHost.unregisterSimulatedRotaryHandler(handlerId)
+            }
+        }
+    }
 
     val mediaSession = remember {
         MediaSession(context, "OrbitPlayer").apply {
@@ -481,6 +514,8 @@ fun PlayerScreen(
     var scale by remember { mutableFloatStateOf(1f) }
     var offsetX by remember { mutableFloatStateOf(0f) }
     var offsetY by remember { mutableFloatStateOf(0f) }
+    var scaleMode by remember { mutableStateOf(PlayerScaleMode.Standard) }
+    var videoViewportSize by remember { mutableStateOf(IntSize.Zero) }
 
     val useTextureView = remember { SharedPreferencesUtil.getBoolean("player_texture_view", true) }
     val effectiveUseTexture = useTextureView && isTextureViewOk.intValue != -1
@@ -742,6 +777,10 @@ fun PlayerScreen(
                     if (hasPrepared) return@setOnPreparedListener
                     hasPrepared = true
                     val startDanmakuPlayback = {
+                        // Apply WatchRSS-style mute-on-start immediately before playback.
+                        // The volume state remembers explicit user changes, so resume and
+                        // subsequent episode switches do not keep forcing the limit.
+                        volumeState.enforcePlaybackStartGuard()
                         viewModel.onPrepared()
                         if (!isAudioOnlyMode && playerData.audioUrl != "audio") {
                             val targetPos = viewModel.currentProgress.value
@@ -960,6 +999,16 @@ fun PlayerScreen(
         animationSpec = tween(durationMillis = 300, easing = androidx.compose.animation.core.FastOutSlowInEasing),
         label = "rotation"
     )
+    val scaleModeMultiplier by animateFloatAsState(
+        targetValue = calculatePlayerScaleMultiplier(
+            viewSize = videoViewportSize,
+            videoWidth = videoWidth,
+            videoHeight = videoHeight,
+            scaleMode = scaleMode
+        ),
+        animationSpec = tween(durationMillis = 250),
+        label = "threeStageScale"
+    )
 
     Box(
         modifier = Modifier
@@ -1100,14 +1149,9 @@ fun PlayerScreen(
                 }
             }
             .onRotaryScrollEvent {
-                if (isPrepared) {
-                    val delta = it.verticalScrollPixels
-                    val newProgress = (currentProgress + delta * 100).toLong().coerceIn(0L, totalDuration)
-                    viewModel.seekTo(newProgress)
-                    danmakuPlayer.seekTo(newProgress)
-                    if (isPlaying) {
-                        viewModel.play()
-                    }
+                val delta = -it.verticalScrollPixels * ROTARY_VOLUME_INPUT_SCALE
+                if (delta != 0f) {
+                    volumeState.adjustByDelta(delta)
                     interactionCounter++
                 }
                 true
@@ -1116,9 +1160,10 @@ fun PlayerScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .onSizeChanged { videoViewportSize = it }
                 .graphicsLayer(
-                    scaleX = scale,
-                    scaleY = scale,
+                    scaleX = scale * scaleModeMultiplier,
+                    scaleY = scale * scaleModeMultiplier,
                     translationX = offsetX,
                     translationY = offsetY
                 ),
@@ -1126,7 +1171,7 @@ fun PlayerScreen(
         ) {
             // Video Surface - fit within round screen safe area by default
             Box(
-                modifier = Modifier.fillMaxSize(if (isRound) 0.86524f else 1f),
+                modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
                 if (useTextureView && isTextureViewOk.intValue == 0) {
@@ -1308,6 +1353,11 @@ fun PlayerScreen(
             )
         }
 
+        PlayerVolumeOverlay(
+            state = volumeState,
+            modifier = Modifier.align(Alignment.Center)
+        )
+
         AnimatedVisibility(
             visible = showControls,
             enter = fadeIn(),
@@ -1378,7 +1428,7 @@ fun PlayerScreen(
                 ) {
                     val renderCustomButton = @Composable { action: Int, modifier: Modifier ->
                         when (action) {
-                            1 -> {
+                            PLAYER_ACTION_DANMAKU -> {
                                 IconButton(
                                     onClick = { showDanmaku = !showDanmaku },
                                     modifier = modifier.size(36.dp)
@@ -1391,7 +1441,7 @@ fun PlayerScreen(
                                     )
                                 }
                             }
-                            2 -> {
+                            PLAYER_ACTION_SPEED -> {
                                 if (!isLive) {
                                     IconButton(
                                         onClick = {
@@ -1420,7 +1470,7 @@ fun PlayerScreen(
                                     }
                                 }
                             }
-                            3 -> {
+                            PLAYER_ACTION_VOLUME -> {
                                 IconButton(
                                     onClick = { showVolumeScreen = true },
                                     modifier = modifier.size(36.dp)
@@ -1433,7 +1483,7 @@ fun PlayerScreen(
                                     )
                                 }
                             }
-                            4 -> {
+                            PLAYER_ACTION_SUBTITLE -> {
                                 IconButton(
                                     onClick = { showSubtitleDialog = true },
                                     modifier = modifier.size(36.dp)
@@ -1446,39 +1496,13 @@ fun PlayerScreen(
                                     )
                                 }
                             }
-                            5 -> {
+                            PLAYER_ACTION_ROTATE -> {
                                 IconButton(
                                     onClick = {
-                                        if (isSoftRotate) {
-                                            val steps = SharedPreferencesUtil.getString("player_softrotate_steps", "0,90,180,270")
-                                                .split(",").mapNotNull { it.trim().toFloatOrNull() }
-                                            if (steps.size >= 2) {
-                                                val currentIdx = steps.indexOfFirst { it == softRotateDegrees }.coerceAtLeast(0)
-                                                val nextIdx = (currentIdx + 1) % steps.size
-                                                val nextDeg = steps[nextIdx]
-                                                if (steps.size == 2) {
-                                                    // 2 directions: animate "from where it came" (back and forth)
-                                                    cumulativeRotation = nextDeg
-                                                } else {
-                                                    // 3+ directions: always rotate clockwise (same direction)
-                                                    val delta = ((nextDeg - cumulativeRotation) % 360 + 360) % 360
-                                                    cumulativeRotation += if (delta == 0f) 360f else delta
-                                                }
-                                                softRotateDegrees = nextDeg
-                                                SharedPreferencesUtil.putFloat("player_softrotate_deg", softRotateDegrees)
-                                            }
-                                        } else {
-                                            val activity = context.findActivity()
-                                            if (activity != null) {
-                                                val current = activity.requestedOrientation
-                                                if (current == android.content.pm.ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE ||
-                                                    current == android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE) {
-                                                    activity.requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                                                } else {
-                                                    activity.requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-                                                }
-                                            }
-                                        }
+                                        cumulativeRotation += 90f
+                                        softRotateDegrees = ((cumulativeRotation % 360f) + 360f) % 360f
+                                        SharedPreferencesUtil.putFloat("player_softrotate_deg", softRotateDegrees)
+                                        interactionCounter++
                                     },
                                     modifier = modifier.size(36.dp)
                                 ) {
@@ -1487,6 +1511,26 @@ fun PlayerScreen(
                                         contentDescription = "Rotate Screen",
                                         tint = Color.White.copy(alpha = 0.9f),
                                         modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                            PLAYER_ACTION_SCALE -> {
+                                val scaleAction = scaleMode.toggleAction()
+                                IconButton(
+                                    onClick = {
+                                        scaleMode = scaleMode.next()
+                                        scale = 1f
+                                        offsetX = 0f
+                                        offsetY = 0f
+                                        interactionCounter++
+                                    },
+                                    modifier = modifier.size(36.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = scaleAction.icon,
+                                        contentDescription = scaleAction.contentDescription,
+                                        tint = Color.White.copy(alpha = 0.9f),
+                                        modifier = Modifier.size(22.dp)
                                     )
                                 }
                             }
@@ -1778,6 +1822,77 @@ fun PlayerScreen(
                     }
                 }
                 item { Spacer(modifier = Modifier.height(32.dp)) }
+            }
+        }
+    }
+}
+
+private enum class PlayerScaleMode {
+    Standard,
+    Expanded,
+    Shrunk;
+
+    fun next(): PlayerScaleMode = when (this) {
+        Standard -> Expanded
+        Expanded -> Shrunk
+        Shrunk -> Standard
+    }
+}
+
+private data class PlayerScaleToggleAction(
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val contentDescription: String
+)
+
+private fun PlayerScaleMode.toggleAction(): PlayerScaleToggleAction = when (this) {
+    PlayerScaleMode.Standard -> PlayerScaleToggleAction(
+        icon = Icons.Filled.Fullscreen,
+        contentDescription = "放大"
+    )
+    PlayerScaleMode.Expanded -> PlayerScaleToggleAction(
+        icon = Icons.Filled.PanoramaFishEye,
+        contentDescription = "缩小"
+    )
+    PlayerScaleMode.Shrunk -> PlayerScaleToggleAction(
+        icon = Icons.Filled.FullscreenExit,
+        contentDescription = "标准"
+    )
+}
+
+private fun calculatePlayerScaleMultiplier(
+    viewSize: IntSize,
+    videoWidth: Float,
+    videoHeight: Float,
+    scaleMode: PlayerScaleMode
+): Float {
+    if (viewSize.width <= 0 || viewSize.height <= 0 || videoWidth <= 0f || videoHeight <= 0f) {
+        return 1f
+    }
+    val viewWidth = viewSize.width.toFloat()
+    val viewHeight = viewSize.height.toFloat()
+    val viewAspect = viewWidth / viewHeight
+    val videoAspect = videoWidth / videoHeight
+    val contentWidth: Float
+    val contentHeight: Float
+    if (videoAspect > viewAspect) {
+        contentWidth = viewWidth
+        contentHeight = viewWidth / videoAspect
+    } else {
+        contentHeight = viewHeight
+        contentWidth = viewHeight * videoAspect
+    }
+    return when (scaleMode) {
+        PlayerScaleMode.Standard -> 1f
+        PlayerScaleMode.Expanded -> max(
+            viewWidth / contentWidth.coerceAtLeast(1f),
+            viewHeight / contentHeight.coerceAtLeast(1f)
+        )
+        PlayerScaleMode.Shrunk -> {
+            val diagonal = sqrt(contentWidth * contentWidth + contentHeight * contentHeight)
+            if (diagonal > 0f) {
+                (min(viewWidth, viewHeight) / diagonal).coerceAtMost(1f)
+            } else {
+                1f
             }
         }
     }

--- a/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerVolumeControl.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerVolumeControl.kt
@@ -1,0 +1,315 @@
+package com.qx.orbit.bili.presentation.player
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Build
+import android.os.SystemClock
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@Stable
+internal class PlayerVolumeState(
+    private val audioManager: AudioManager,
+    private val scope: CoroutineScope,
+    private val guardEnabled: Boolean,
+    private val playbackStartVolumeLimitPercent: Int?,
+    private val onVolumeGuardTriggered: () -> Unit
+) {
+    private val minVolume = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        audioManager.getStreamMinVolume(AudioManager.STREAM_MUSIC)
+    } else {
+        0
+    }
+    private val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+    private val volumeSensitivity = (maxVolume - minVolume) * VOLUME_SENSITIVITY_PERCENT
+    private val digitalCrownSessionCapVolume = volumeForPercent(
+        targetPercent = DIGITAL_CROWN_SESSION_CAP_PERCENT,
+        minVolume = minVolume,
+        maxVolume = maxVolume
+    )
+    private var hideJob: Job? = null
+    private var digitalCrownGuardState by mutableStateOf(DigitalCrownVolumeGuardState())
+    private var playbackStartGuardDismissedByUser by mutableStateOf(false)
+    private var virtualVolume by mutableFloatStateOf(readCurrentVolume().toFloat())
+
+    var currentVolume by mutableIntStateOf(readCurrentVolume())
+        private set
+
+    var isVisible by mutableStateOf(false)
+        private set
+
+    val progress: Float
+        get() {
+            if (maxVolume <= minVolume) return 0f
+            return ((virtualVolume - minVolume) / (maxVolume - minVolume)).coerceIn(0f, 1f)
+        }
+
+    val percentText: String
+        get() = "${(progress * 100f).roundToInt()}%"
+
+    fun adjustByDelta(delta: Float, eventUptimeMs: Long = SystemClock.elapsedRealtime()) {
+        if (delta == 0f) return
+        playbackStartGuardDismissedByUser = true
+        syncOutOfBandVolumeChange()
+        val guardedTarget = applyDigitalCrownVolumeGuard(
+            currentVolume = virtualVolume,
+            requestedDeltaVolume = delta * volumeSensitivity,
+            minVolume = minVolume,
+            maxVolume = maxVolume,
+            guardEnabled = guardEnabled,
+            sessionCapVolume = digitalCrownSessionCapVolume,
+            previousState = digitalCrownGuardState,
+            eventUptimeMs = eventUptimeMs
+        )
+        digitalCrownGuardState = guardedTarget.nextState
+        virtualVolume = guardedTarget.targetVolume
+        if (guardedTarget.shouldNotifyGuardTriggered) {
+            onVolumeGuardTriggered()
+        }
+        setVolume(virtualVolume.roundToInt())
+        show()
+    }
+
+    fun enforcePlaybackStartGuard() {
+        syncOutOfBandVolumeChange()
+        val current = readCurrentVolume()
+        val targetVolume = playbackStartVolumeLimitPercent?.let {
+            playbackStartVolumeForPercent(it, minVolume, maxVolume)
+        }
+        if (!shouldEnforcePlaybackStartGuard(
+                playbackStartVolumeLimitPercent = playbackStartVolumeLimitPercent,
+                dismissedByUser = playbackStartGuardDismissedByUser,
+                currentVolume = current,
+                minVolume = minVolume,
+                maxVolume = maxVolume
+            )
+        ) {
+            return
+        }
+        virtualVolume = targetVolume ?: current.toFloat()
+        setVolume(virtualVolume.roundToInt())
+        show()
+    }
+
+    private fun readCurrentVolume(): Int {
+        return audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).coerceIn(minVolume, maxVolume)
+    }
+
+    private fun syncOutOfBandVolumeChange() {
+        val actual = readCurrentVolume()
+        if (actual == currentVolume) return
+        playbackStartGuardDismissedByUser = true
+        digitalCrownGuardState = DigitalCrownVolumeGuardState()
+        currentVolume = actual
+        virtualVolume = actual.toFloat()
+    }
+
+    private fun setVolume(target: Int) {
+        val clampedTarget = target.coerceIn(minVolume, maxVolume)
+        if (!audioManager.isVolumeFixed && clampedTarget != readCurrentVolume()) {
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, clampedTarget, 0)
+        }
+        currentVolume = readCurrentVolume()
+    }
+
+    private fun show() {
+        isVisible = true
+        hideJob?.cancel()
+        hideJob = scope.launch {
+            delay(VOLUME_OVERLAY_HIDE_DELAY_MS)
+            isVisible = false
+        }
+    }
+}
+
+@Composable
+internal fun rememberPlayerVolumeState(
+    guardEnabled: Boolean = true,
+    playbackStartVolumeLimitPercent: Int? = PLAYBACK_START_VOLUME_LIMIT_PERCENT
+): PlayerVolumeState {
+    val context = LocalContext.current
+    val appContext = context.applicationContext
+    val audioManager = remember(appContext) {
+        appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+    val scope = rememberCoroutineScope()
+    return remember(audioManager, scope, guardEnabled, playbackStartVolumeLimitPercent, appContext) {
+        PlayerVolumeState(
+            audioManager = audioManager,
+            scope = scope,
+            guardEnabled = guardEnabled,
+            playbackStartVolumeLimitPercent = playbackStartVolumeLimitPercent,
+            onVolumeGuardTriggered = {
+                Toast.makeText(appContext, VOLUME_GUARD_TRIGGERED_TOAST, Toast.LENGTH_SHORT).show()
+            }
+        )
+    }
+}
+
+@Composable
+internal fun PlayerVolumeOverlay(
+    state: PlayerVolumeState,
+    modifier: Modifier = Modifier
+) {
+    if (!state.isVisible) return
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.86f))
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.VolumeUp,
+            contentDescription = "音量",
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(18.dp)
+        )
+        Text(
+            text = "：${state.percentText}",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+private data class DigitalCrownVolumeGuardState(
+    val sessionCapVolume: Float? = null,
+    val lastEventUptimeMs: Long = Long.MIN_VALUE,
+    val guardNotificationShown: Boolean = false
+)
+
+private data class DigitalCrownVolumeGuardResult(
+    val targetVolume: Float,
+    val nextState: DigitalCrownVolumeGuardState,
+    val shouldNotifyGuardTriggered: Boolean = false
+)
+
+private fun applyDigitalCrownVolumeGuard(
+    currentVolume: Float,
+    requestedDeltaVolume: Float,
+    minVolume: Int,
+    maxVolume: Int,
+    guardEnabled: Boolean,
+    sessionCapVolume: Float,
+    previousState: DigitalCrownVolumeGuardState,
+    eventUptimeMs: Long
+): DigitalCrownVolumeGuardResult {
+    val clampedCurrent = currentVolume.coerceIn(minVolume.toFloat(), maxVolume.toFloat())
+    if (requestedDeltaVolume == 0f) {
+        return DigitalCrownVolumeGuardResult(clampedCurrent, previousState)
+    }
+
+    val isNewSession = previousState.lastEventUptimeMs == Long.MIN_VALUE ||
+        eventUptimeMs - previousState.lastEventUptimeMs > DIGITAL_CROWN_SESSION_IDLE_TIMEOUT_MS
+    val direction = requestedDeltaVolume.compareTo(0f)
+    var activeCapVolume = if (isNewSession || direction <= 0 || !guardEnabled) {
+        null
+    } else {
+        previousState.sessionCapVolume
+    }
+    var guardNotificationShown = activeCapVolume?.let { previousState.guardNotificationShown } ?: false
+    var targetVolume = (clampedCurrent + requestedDeltaVolume)
+        .coerceIn(minVolume.toFloat(), maxVolume.toFloat())
+    var wasLimitedByGuard = false
+
+    if (guardEnabled && direction > 0) {
+        val capActivationVolume = sessionCapVolume.roundToInt()
+            .coerceIn(minVolume, maxVolume)
+            .toFloat()
+        val effectiveCapVolume = activeCapVolume ?: if (clampedCurrent < capActivationVolume) {
+            sessionCapVolume
+        } else {
+            null
+        }
+        if (effectiveCapVolume != null) {
+            activeCapVolume = effectiveCapVolume
+            val cappedTargetVolume = targetVolume.coerceAtMost(effectiveCapVolume)
+            wasLimitedByGuard = cappedTargetVolume < targetVolume
+            targetVolume = cappedTargetVolume
+        }
+    }
+
+    val shouldNotifyGuardTriggered = wasLimitedByGuard && !guardNotificationShown
+    if (shouldNotifyGuardTriggered) guardNotificationShown = true
+    return DigitalCrownVolumeGuardResult(
+        targetVolume = targetVolume,
+        nextState = DigitalCrownVolumeGuardState(
+            sessionCapVolume = activeCapVolume,
+            lastEventUptimeMs = eventUptimeMs,
+            guardNotificationShown = guardNotificationShown
+        ),
+        shouldNotifyGuardTriggered = shouldNotifyGuardTriggered
+    )
+}
+
+private fun shouldEnforcePlaybackStartGuard(
+    playbackStartVolumeLimitPercent: Int?,
+    dismissedByUser: Boolean,
+    currentVolume: Int,
+    minVolume: Int,
+    maxVolume: Int
+): Boolean {
+    if (playbackStartVolumeLimitPercent == null || dismissedByUser) return false
+    val targetVolume = playbackStartVolumeForPercent(
+        playbackStartVolumeLimitPercent,
+        minVolume,
+        maxVolume
+    )
+    return currentVolume.coerceIn(minVolume, maxVolume).toFloat() > targetVolume
+}
+
+private fun playbackStartVolumeForPercent(
+    targetPercent: Int,
+    minVolume: Int,
+    maxVolume: Int
+): Float {
+    return volumeForPercent(targetPercent.coerceIn(0, 100) / 100f, minVolume, maxVolume)
+}
+
+private fun volumeForPercent(targetPercent: Float, minVolume: Int, maxVolume: Int): Float {
+    if (maxVolume <= minVolume || targetPercent <= 0f) return minVolume.toFloat()
+    val range = (maxVolume - minVolume).coerceAtLeast(1)
+    return (minVolume + range * targetPercent)
+        .coerceIn((minVolume + 1).toFloat(), maxVolume.toFloat())
+}
+
+internal const val ROTARY_VOLUME_INPUT_SCALE = 0.01f
+
+private const val PLAYBACK_START_VOLUME_LIMIT_PERCENT = 10
+private const val VOLUME_OVERLAY_HIDE_DELAY_MS = 1_200L
+private const val DIGITAL_CROWN_SESSION_IDLE_TIMEOUT_MS = 600L
+private const val DIGITAL_CROWN_SESSION_CAP_PERCENT = 0.21f
+private const val VOLUME_SENSITIVITY_PERCENT = 0.06f
+private const val VOLUME_GUARD_TRIGGERED_TOAST = "音量调节防干扰触发，先停下以继续调整音量"

--- a/app/src/main/java/com/qx/orbit/bili/presentation/settings/PlayerCustomizationScreen.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/settings/PlayerCustomizationScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.ScreenRotation
 import androidx.compose.material.icons.filled.ScreenRotationAlt
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -56,20 +57,32 @@ import com.qx.orbit.bili.presentation.ui.components.adaptiveTransformedHeight
 import androidx.wear.compose.material3.SurfaceTransformation
 import com.qx.orbit.bili.presentation.theme.LocalScreenRound
 import com.qx.orbit.bili.presentation.util.rememberSafeRotaryScrollableBehavior
+import com.qx.orbit.bili.presentation.player.PLAYER_ACTION_DANMAKU
+import com.qx.orbit.bili.presentation.player.PLAYER_ACTION_ROTATE
+import com.qx.orbit.bili.presentation.player.PLAYER_ACTION_SCALE
+import com.qx.orbit.bili.presentation.player.PLAYER_ACTION_SPEED
+import com.qx.orbit.bili.presentation.player.PLAYER_ACTION_SUBTITLE
+import com.qx.orbit.bili.presentation.player.PLAYER_ACTION_VOLUME
+import com.qx.orbit.bili.presentation.player.PLAYER_LEFT_BOTTOM_KEY
+import com.qx.orbit.bili.presentation.player.PLAYER_LEFT_TOP_KEY
+import com.qx.orbit.bili.presentation.player.PLAYER_RIGHT_BOTTOM_KEY
+import com.qx.orbit.bili.presentation.player.PLAYER_RIGHT_TOP_KEY
+import com.qx.orbit.bili.presentation.player.loadPlayerControlLayout
 
 @Composable
 fun PlayerCustomizationScreen(
     onBack: () -> Unit
 ) {
-    var leftTopBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_left", 2)) }
-    var leftBottomBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_left_bottom", 0)) }
-    var rightTopBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_right", 1)) }
-    var rightBottomBtnAction by remember { mutableIntStateOf(SharedPreferencesUtil.getInt("player_custom_btn_right_bottom", 0)) }
+    val initialLayout = remember { loadPlayerControlLayout() }
+    var leftTopBtnAction by remember { mutableIntStateOf(initialLayout.leftTop) }
+    var leftBottomBtnAction by remember { mutableIntStateOf(initialLayout.leftBottom) }
+    var rightTopBtnAction by remember { mutableIntStateOf(initialLayout.rightTop) }
+    var rightBottomBtnAction by remember { mutableIntStateOf(initialLayout.rightBottom) }
     
     var showActionDialog by remember { mutableStateOf(false) }
     var configuringSide by remember { mutableIntStateOf(0) } // 0: LT, 1: LB, 2: RT, 3: RB
 
-    val actionNames = listOf("无操作", "弹幕开关", "倍速播放", "音量调节", "字幕设置", "旋转屏幕")
+    val actionNames = listOf("无操作", "弹幕开关", "倍速播放", "音量调节", "字幕设置", "旋转屏幕", "三段缩放")
 
     Box(
         modifier = Modifier
@@ -227,19 +240,19 @@ fun PlayerCustomizationScreen(
                                 when(configuringSide) {
                                     0 -> {
                                         leftTopBtnAction = index
-                                        SharedPreferencesUtil.putInt("player_custom_btn_left", index)
+                                        SharedPreferencesUtil.putInt(PLAYER_LEFT_TOP_KEY, index)
                                     }
                                     1 -> {
                                         leftBottomBtnAction = index
-                                        SharedPreferencesUtil.putInt("player_custom_btn_left_bottom", index)
+                                        SharedPreferencesUtil.putInt(PLAYER_LEFT_BOTTOM_KEY, index)
                                     }
                                     2 -> {
                                         rightTopBtnAction = index
-                                        SharedPreferencesUtil.putInt("player_custom_btn_right", index)
+                                        SharedPreferencesUtil.putInt(PLAYER_RIGHT_TOP_KEY, index)
                                     }
                                     3 -> {
                                         rightBottomBtnAction = index
-                                        SharedPreferencesUtil.putInt("player_custom_btn_right_bottom", index)
+                                        SharedPreferencesUtil.putInt(PLAYER_RIGHT_BOTTOM_KEY, index)
                                     }
                                 }
                                 showActionDialog = false
@@ -269,7 +282,7 @@ fun PlayerCustomizationScreen(
 @Composable
 fun PlayerActionIcon(action: Int) {
     when (action) {
-        1 -> {
+        PLAYER_ACTION_DANMAKU -> {
             Icon(
                 painter = painterResource(R.drawable.ic_danmaku_inline_switch_v2_on),
                 contentDescription = "Danmaku",
@@ -277,7 +290,7 @@ fun PlayerActionIcon(action: Int) {
                 modifier = Modifier.size(36.dp)
             )
         }
-        2 -> {
+        PLAYER_ACTION_SPEED -> {
             Icon(
                 painter = painterResource(R.drawable.speed_1x),
                 contentDescription = "Playback Speed",
@@ -285,7 +298,7 @@ fun PlayerActionIcon(action: Int) {
                 modifier = Modifier.size(28.dp)
             )
         }
-        3 -> {
+        PLAYER_ACTION_VOLUME -> {
             Icon(
                 imageVector = Icons.AutoMirrored.Default.VolumeUp,
                 contentDescription = "Volume",
@@ -293,7 +306,7 @@ fun PlayerActionIcon(action: Int) {
                 modifier = Modifier.size(24.dp)
             )
         }
-        4 -> {
+        PLAYER_ACTION_SUBTITLE -> {
             Icon(
                 painter = painterResource(R.drawable.ic_subtitle_setting),
                 contentDescription = "Subtitle",
@@ -301,12 +314,20 @@ fun PlayerActionIcon(action: Int) {
                 modifier = Modifier.size(24.dp)
             )
         }
-        5 -> {
+        PLAYER_ACTION_ROTATE -> {
             Icon(
                 imageVector = Icons.Filled.ScreenRotation,
                 contentDescription = "Rotate Screen",
                 tint = Color.White.copy(alpha = 0.9f),
                 modifier = Modifier.size(20.dp)
+            )
+        }
+        PLAYER_ACTION_SCALE -> {
+            Icon(
+                imageVector = Icons.Filled.Fullscreen,
+                contentDescription = "Three-stage Scale",
+                tint = Color.White.copy(alpha = 0.9f),
+                modifier = Modifier.size(22.dp)
             )
         }
         else -> {

--- a/app/src/main/java/com/qx/orbit/bili/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/viewmodel/PlayerViewModel.kt
@@ -16,6 +16,7 @@ import com.qx.orbit.bili.data.remote.CookieManager
 import com.qx.orbit.bili.util.player.OrbitPlayer
 import com.qx.orbit.bili.util.player.createOrbitPlayer
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,7 +33,7 @@ class PlayerViewModel : ViewModel() {
 
     fun initPlayer(context: Context) {
         if (::_player.isInitialized) return
-        _player = createOrbitPlayer(context)
+        _player = createOrbitPlayer(context.applicationContext)
     }
 
     // --- State ---
@@ -91,6 +92,11 @@ class PlayerViewModel : ViewModel() {
     private var switchPendingSeekMs = -1L
     private var startTs = 0L
     private var heartbeatStarted = false
+    private var heartbeatJob: Job? = null
+    private var bufferSpeedJob: Job? = null
+    private var liveElapsedJob: Job? = null
+    private var subtitleCursor = 0
+    private var released = false
 
     /**
      * Read position directly from player, bypassing the currentProgress flow
@@ -122,12 +128,21 @@ class PlayerViewModel : ViewModel() {
         _isLoading.value = loading
     }
 
+    fun beginPlaybackPreparation() {
+        _isPrepared.value = false
+        _isLoading.value = true
+        heartbeatStarted = false
+        heartbeatJob?.cancel()
+        heartbeatJob = null
+    }
+
     fun setError(msg: String?) {
         _errorMessage.value = msg
     }
 
     fun setSubtitles(subs: Array<Subtitle>) {
         _subtitles.value = subs
+        subtitleCursor = 0
     }
 
     fun setSubtitleLinks(links: Array<SubtitleLink>) {
@@ -185,8 +200,7 @@ class PlayerViewModel : ViewModel() {
 
     fun preparePlayback(initialData: PlayerData, isAudioOnlyMode: Boolean) {
         // Stop heartbeat loop before player reset (prevents currentProgress from being zeroed)
-        _isPrepared.value = false
-        heartbeatStarted = false
+        beginPlaybackPreparation()
         val data = _playerData.value
         viewModelScope.launch(Dispatchers.IO) {
             try {
@@ -224,7 +238,12 @@ class PlayerViewModel : ViewModel() {
 
     private fun configureAndStartPlayer(data: PlayerData, isAudioOnlyMode: Boolean) {
         _player.reset()
-        _player.setDashData(data.dashData, data.videoUrl, data.audioUrl)
+        val useAudioOnlySource = !isLocal && isAudioOnlyMode && data.audioUrl.isNotEmpty()
+        if (useAudioOnlySource) {
+            _player.setDashData(null, data.audioUrl, "")
+        } else {
+            _player.setDashData(data.dashData, data.videoUrl, data.audioUrl)
+        }
         _player.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "enable-accurate-seek", 1)
         _player.setOption(OrbitPlayer.OPT_CATEGORY_FORMAT, "allowed_extensions", "ALL")
         _player.setOption(OrbitPlayer.OPT_CATEGORY_FORMAT, "protocol_whitelist", "file,http,https,tcp,tls,crypto")
@@ -242,11 +261,11 @@ class PlayerViewModel : ViewModel() {
             _player.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "packet-buffering", 0)
             _player.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "infbuf", 1)
         }
+        if (BuildConfig.HAS_IJK) {
+            _player.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "vn", if (useAudioOnlySource) 1 else 0)
+        }
         if (isAudioOnlyMode && !isLocal) {
             // Power-saving: disable video decode (IJK only), minimize buffer
-            if (BuildConfig.HAS_IJK) {
-                _player.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "vn", 1)
-            }
             _player.setOption(OrbitPlayer.OPT_CATEGORY_FORMAT, "reconnect_delay_max", 2)
             _player.setOption(OrbitPlayer.OPT_CATEGORY_PLAYER, "max-buffer-size", 1024 * 1024)
             _player.setOption(OrbitPlayer.OPT_CATEGORY_FORMAT, "timeout", 5000000)
@@ -433,7 +452,15 @@ class PlayerViewModel : ViewModel() {
     }
 
     fun release() {
+        if (released || !::_player.isInitialized) return
+        released = true
+        if (_isPrepared.value) {
+            try { _currentProgress.value = _player.currentPosition } catch (_: Exception) {}
+        }
         reportProgress()
+        heartbeatJob?.cancel()
+        bufferSpeedJob?.cancel()
+        liveElapsedJob?.cancel()
         _player.release()
     }
 
@@ -464,7 +491,8 @@ class PlayerViewModel : ViewModel() {
 
     private fun startHeartbeatLoop() {
         startTs = _currentProgress.value / 1000
-        viewModelScope.launch {
+        heartbeatJob?.cancel()
+        heartbeatJob = viewModelScope.launch {
             while (isActive && _isPrepared.value) {
                 delay(15.seconds)
                 updateProgress()
@@ -482,12 +510,27 @@ class PlayerViewModel : ViewModel() {
             return
         }
         val timeSec = progress / 1000.0
-        val matched = subs.find { timeSec >= it.from && timeSec < it.to }
+        if (subtitleCursor !in subs.indices || timeSec < subs[subtitleCursor].from) {
+            var low = 0
+            var high = subs.size
+            while (low < high) {
+                val mid = (low + high) ushr 1
+                if (subs[mid].to <= timeSec) low = mid + 1 else high = mid
+            }
+            subtitleCursor = low.coerceAtMost(subs.lastIndex)
+        } else {
+            while (subtitleCursor < subs.lastIndex && timeSec >= subs[subtitleCursor].to) {
+                subtitleCursor++
+            }
+        }
+        val candidate = subs[subtitleCursor]
+        val matched = candidate.takeIf { timeSec >= it.from && timeSec < it.to }
         _currentSubtitle.value = matched?.content
     }
 
     fun startBufferSpeedLoop() {
-        viewModelScope.launch {
+        bufferSpeedJob?.cancel()
+        bufferSpeedJob = viewModelScope.launch {
             while (isActive && _isLoading.value) {
                 updateBufferSpeed()
                 delay(1.seconds)
@@ -497,8 +540,12 @@ class PlayerViewModel : ViewModel() {
     }
 
     fun startLiveElapsedTimer(timeStamp: Long) {
-        if (timeStamp <= 0) return
-        viewModelScope.launch {
+        liveElapsedJob?.cancel()
+        if (timeStamp <= 0) {
+            _liveElapsedSeconds.value = 0L
+            return
+        }
+        liveElapsedJob = viewModelScope.launch {
             while (isActive) {
                 _liveElapsedSeconds.value = (System.currentTimeMillis() / 1000) - timeStamp
                 delay(1.seconds)
@@ -507,9 +554,7 @@ class PlayerViewModel : ViewModel() {
     }
 
     override fun onCleared() {
+        release()
         super.onCleared()
-        if (::_player.isInitialized) {
-            _player.release()
-        }
     }
 }


### PR DESCRIPTION
## What changed

- reduce player progress and subtitle UI updates from display-frame frequency to 4 Hz
- keep playback lifecycle jobs single-instance and cancelable in `PlayerViewModel`
- parallelize playback URL loading with danmaku preparation
- cache media artwork, reuse the shared HTTP client, and release video surfaces correctly
- avoid video decode in audio-only playback while retaining both IJK and Media3 paths
- add a Baseline Profile for Orbit screens and native Wear Compose transforming-list hot paths
- port WatchRSS player controls: native crown and simulated wheel volume adjustment, volume-interference guard, playback-start volume limiting, 90-degree rotation, and three-stage scaling
- change only the default control layout to scale/rotate on the left and speed/danmaku on the right; keep all existing saved custom button positions

## Why

The player was driving full Compose updates every rendered frame and repeating work such as metadata/image loading and linear subtitle scans. Wear Compose scrolling also benefited from compiling its hot paths ahead of time on the target ARMv7 low-RAM watch.

The WatchRSS controls bring the same watch-friendly playback interactions into Orbit while preserving its existing four-slot customization model.

## Impact

- lower player recomposition, subtitle, network, and media-session overhead
- faster first-use and steady-state scrolling without reducing animation or replacing native Wear components
- safer, easier volume control from both a physical crown and simulated wheel input
- rotation and scaling available from the default left-side controls, with playback speed on the right
- existing users' stored button customizations remain unchanged

On the target watch, the profile build measured:

- home: 24.69 ms/frame cold baseline to 11.00 ms/frame after install; 10.35 ms/frame steady-state
- settings: 23.29 ms/frame to 9.21 ms/frame
- dynamic feed: 10.83 ms/frame

## Validation

- `./gradlew --no-daemon :app:compileFullDebugKotlin :app:compileLiteDebugKotlin`
- `./gradlew --no-daemon :app:assembleFullDebug :app:testFullDebugUnitTest :app:testLiteDebugUnitTest :DFMNext:testDebugUnitTest`
- `./gradlew --no-daemon :app:assembleFullRelease`
- `git diff --check`
- signed the full release APK with the existing OPPO_Develop certificate
- installed the signed ARMv7 APK on the target watch and launched it without an observed crash
- release APK contains the Baseline Profile and ART reports `speed-profile` / `install-dm`
