### PR TITLE
Add player volume settings

### DIFF
--- a/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerScreen.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerScreen.kt
@@ -236,9 +236,31 @@ fun PlayerScreen(
     var showVolumeScreen by remember { mutableStateOf(false) }
     var showMoreDialog by remember { mutableStateOf(false) }
     val audioManager = remember { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
+    val rotaryVolumeEnabled = remember {
+        SharedPreferencesUtil.getBoolean(
+            PLAYER_ROTARY_VOLUME_ENABLED_KEY,
+            DEFAULT_PLAYER_ROTARY_VOLUME_ENABLED
+        )
+    }
+    val volumeGuardEnabled = remember {
+        SharedPreferencesUtil.getBoolean(
+            PLAYER_VOLUME_GUARD_ENABLED_KEY,
+            DEFAULT_PLAYER_VOLUME_GUARD_ENABLED
+        )
+    }
+    val muteOnStartEnabled = remember {
+        SharedPreferencesUtil.getBoolean(
+            PLAYER_MUTE_ON_START_ENABLED_KEY,
+            DEFAULT_PLAYER_MUTE_ON_START_ENABLED
+        )
+    }
     val volumeState = rememberPlayerVolumeState(
-        guardEnabled = true,
-        playbackStartVolumeLimitPercent = 10
+        guardEnabled = volumeGuardEnabled,
+        playbackStartVolumeLimitPercent = if (muteOnStartEnabled) {
+            PLAYER_MUTE_ON_START_VOLUME_PERCENT
+        } else {
+            null
+        }
     )
     val simulatedRotaryHost = remember(context) { context.findActivity() as? MainActivity }
     
@@ -299,20 +321,24 @@ fun PlayerScreen(
     val danmakuPlayer = remember { createDanmakuPlayer(context) }
     var danmakuConfig by remember { mutableStateOf<DanmakuConfig?>(null) }
 
-    DisposableEffect(simulatedRotaryHost, volumeState) {
-        val handlerId = simulatedRotaryHost?.registerSimulatedRotaryHandler { rawDelta ->
-            val delta = -rawDelta * ROTARY_VOLUME_INPUT_SCALE
-            if (delta == 0f) {
-                false
-            } else {
-                volumeState.adjustByDelta(delta)
-                interactionCounter++
-                true
+    DisposableEffect(simulatedRotaryHost, volumeState, rotaryVolumeEnabled) {
+        val handlerId = if (rotaryVolumeEnabled) {
+            simulatedRotaryHost?.registerSimulatedRotaryHandler { rawDelta ->
+                val delta = -rawDelta * ROTARY_VOLUME_INPUT_SCALE
+                if (delta == 0f) {
+                    false
+                } else {
+                    volumeState.adjustByDelta(delta)
+                    interactionCounter++
+                    true
+                }
             }
+        } else {
+            null
         }
         onDispose {
             if (handlerId != null) {
-                simulatedRotaryHost.unregisterSimulatedRotaryHandler(handlerId)
+                simulatedRotaryHost?.unregisterSimulatedRotaryHandler(handlerId)
             }
         }
     }
@@ -1149,9 +1175,21 @@ fun PlayerScreen(
                 }
             }
             .onRotaryScrollEvent {
-                val delta = -it.verticalScrollPixels * ROTARY_VOLUME_INPUT_SCALE
-                if (delta != 0f) {
-                    volumeState.adjustByDelta(delta)
+                if (rotaryVolumeEnabled) {
+                    val delta = -it.verticalScrollPixels * ROTARY_VOLUME_INPUT_SCALE
+                    if (delta != 0f) {
+                        volumeState.adjustByDelta(delta)
+                        interactionCounter++
+                    }
+                } else if (isPrepared) {
+                    val newProgress = (currentProgress + it.verticalScrollPixels * 100)
+                        .toLong()
+                        .coerceIn(0L, totalDuration)
+                    viewModel.seekTo(newProgress)
+                    danmakuPlayer.seekTo(newProgress)
+                    if (isPlaying) {
+                        viewModel.play()
+                    }
                     interactionCounter++
                 }
                 true

--- a/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerVolumeControl.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/player/PlayerVolumeControl.kt
@@ -305,6 +305,15 @@ private fun volumeForPercent(targetPercent: Float, minVolume: Int, maxVolume: In
         .coerceIn((minVolume + 1).toFloat(), maxVolume.toFloat())
 }
 
+internal const val PLAYER_ROTARY_VOLUME_ENABLED_KEY = "player_rotary_volume_enabled"
+internal const val PLAYER_VOLUME_GUARD_ENABLED_KEY = "player_volume_guard_enabled"
+internal const val PLAYER_MUTE_ON_START_ENABLED_KEY = "player_mute_on_start_enabled"
+
+internal const val DEFAULT_PLAYER_ROTARY_VOLUME_ENABLED = true
+internal const val DEFAULT_PLAYER_VOLUME_GUARD_ENABLED = false
+internal const val DEFAULT_PLAYER_MUTE_ON_START_ENABLED = false
+internal const val PLAYER_MUTE_ON_START_VOLUME_PERCENT = 10
+
 internal const val ROTARY_VOLUME_INPUT_SCALE = 0.01f
 
 private const val PLAYBACK_START_VOLUME_LIMIT_PERCENT = 10

--- a/app/src/main/java/com/qx/orbit/bili/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/qx/orbit/bili/presentation/settings/SettingsScreen.kt
@@ -67,6 +67,12 @@ import com.google.gson.Gson
 import com.qx.orbit.bili.R
 import com.qx.orbit.bili.data.remote.CookieManager
 import com.qx.orbit.bili.presentation.MainActivity
+import com.qx.orbit.bili.presentation.player.DEFAULT_PLAYER_MUTE_ON_START_ENABLED
+import com.qx.orbit.bili.presentation.player.DEFAULT_PLAYER_ROTARY_VOLUME_ENABLED
+import com.qx.orbit.bili.presentation.player.DEFAULT_PLAYER_VOLUME_GUARD_ENABLED
+import com.qx.orbit.bili.presentation.player.PLAYER_MUTE_ON_START_ENABLED_KEY
+import com.qx.orbit.bili.presentation.player.PLAYER_ROTARY_VOLUME_ENABLED_KEY
+import com.qx.orbit.bili.presentation.player.PLAYER_VOLUME_GUARD_ENABLED_KEY
 import com.qx.orbit.bili.presentation.theme.LocalScreenRound
 import com.qx.orbit.bili.presentation.ui.components.RoundToast
 import com.qx.orbit.bili.presentation.ui.components.ShizukuActivationDialog
@@ -342,6 +348,30 @@ fun SettingApsisPlayerScreen(navController: NavController) {
     val listState = rememberTransformingLazyColumnState()
     val transformationSpec = rememberTransformationSpec()
     val isRound = LocalScreenRound.current
+    var rotaryVolumeEnabled by remember {
+        mutableStateOf(
+            SharedPreferencesUtil.getBoolean(
+                PLAYER_ROTARY_VOLUME_ENABLED_KEY,
+                DEFAULT_PLAYER_ROTARY_VOLUME_ENABLED
+            )
+        )
+    }
+    var volumeGuardEnabled by remember {
+        mutableStateOf(
+            SharedPreferencesUtil.getBoolean(
+                PLAYER_VOLUME_GUARD_ENABLED_KEY,
+                DEFAULT_PLAYER_VOLUME_GUARD_ENABLED
+            )
+        )
+    }
+    var muteOnStartEnabled by remember {
+        mutableStateOf(
+            SharedPreferencesUtil.getBoolean(
+                PLAYER_MUTE_ON_START_ENABLED_KEY,
+                DEFAULT_PLAYER_MUTE_ON_START_ENABLED
+            )
+        )
+    }
 
     ScreenScaffold(
         timeText = { WysTimeText() },
@@ -416,6 +446,76 @@ fun SettingApsisPlayerScreen(navController: NavController) {
                 Triple("player_danmaku_showsender", "显示直播弹幕发送者", true),
                 Triple("player_ui_showDanmakuBtn", "显示弹幕按钮", true)
             )
+            item {
+                SwitchButton(
+                    checked = rotaryVolumeEnabled,
+                    onCheckedChange = { isChecked ->
+                        rotaryVolumeEnabled = isChecked
+                        SharedPreferencesUtil.putBoolean(
+                            PLAYER_ROTARY_VOLUME_ENABLED_KEY,
+                            isChecked
+                        )
+                    },
+                    label = {
+                        Text(
+                            text = "使用滚轮调节音量",
+                            maxLines = 1,
+                            modifier = Modifier.basicMarquee()
+                        )
+                    },
+                    transformation = if (isRound) SurfaceTransformation(transformationSpec) else null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .adaptiveTransformedHeight(this, transformationSpec)
+                )
+            }
+            item {
+                SwitchButton(
+                    checked = volumeGuardEnabled,
+                    enabled = rotaryVolumeEnabled,
+                    onCheckedChange = { isChecked ->
+                        volumeGuardEnabled = isChecked
+                        SharedPreferencesUtil.putBoolean(
+                            PLAYER_VOLUME_GUARD_ENABLED_KEY,
+                            isChecked
+                        )
+                    },
+                    label = {
+                        Text(
+                            text = "音量调节防干扰",
+                            maxLines = 1,
+                            modifier = Modifier.basicMarquee()
+                        )
+                    },
+                    transformation = if (isRound) SurfaceTransformation(transformationSpec) else null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .adaptiveTransformedHeight(this, transformationSpec)
+                )
+            }
+            item {
+                SwitchButton(
+                    checked = muteOnStartEnabled,
+                    onCheckedChange = { isChecked ->
+                        muteOnStartEnabled = isChecked
+                        SharedPreferencesUtil.putBoolean(
+                            PLAYER_MUTE_ON_START_ENABLED_KEY,
+                            isChecked
+                        )
+                    },
+                    label = {
+                        Text(
+                            text = "静音开播",
+                            maxLines = 1,
+                            modifier = Modifier.basicMarquee()
+                        )
+                    },
+                    transformation = if (isRound) SurfaceTransformation(transformationSpec) else null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .adaptiveTransformedHeight(this, transformationSpec)
+                )
+            }
             item {
                 Button(
                     onClick = { navController.navigate("settings_player_customization") },


### PR DESCRIPTION
## What changed

- add three switches under **Apsis Player 设置** for rotary volume control, volume-adjustment interference protection, and mute-on-start behavior
- keep rotary volume control enabled by default
- keep volume protection and mute-on-start disabled by default
- disable the protection switch when rotary volume control is unavailable
- restore the original crown seek behavior when rotary volume control is turned off
- stop intercepting simulated wheel events when rotary volume control is turned off

## Why

The WatchRSS player controls were previously wired with fixed values, so users could not choose whether the safety and playback-start behavior should apply. These settings expose the controls while preserving Orbit's original crown seek behavior when volume control is disabled.

## Impact

- existing users get rotary volume control by default
- volume protection and the 10% playback-start limit require explicit opt-in
- all three preferences persist through Orbit's existing shared settings storage

## Validation

- `./gradlew --no-daemon :app:compileFullDebugKotlin :app:compileLiteDebugKotlin`
- `./gradlew --no-daemon :app:testFullDebugUnitTest :app:testLiteDebugUnitTest :DFMNext:testDebugUnitTest`
- `git diff --check`
